### PR TITLE
Improvements in selection tools

### DIFF
--- a/selection_tools/apply_selections.C
+++ b/selection_tools/apply_selections.C
@@ -14,7 +14,7 @@ using namespace std;
 int max_events = 10000;
 int n_daughters = 100;
 
-TFile *input_file, *output_file_siblings, *output_file_non_siblings;
+TFile *input_file, *output_file_single_muon, *output_file_siblings, *output_file_non_siblings;
 
 TTree* get_input_tree(string input_path)
 {
@@ -28,13 +28,19 @@ TTree* get_input_tree(string input_path)
   return (TTree*)input_file->Get("Events");
 }
 
-tuple<TTree*, TTree*> get_output_trees(TTree *input_tree, string siblings_path, string non_siblings_path, string file_name)
+tuple<TTree*, TTree*, TTree*> get_output_trees(TTree *input_tree, string file_name,
+                                               string single_muon_path, string siblings_path, string non_siblings_path)
 {
+  system(("mkdir -p " + single_muon_path).c_str());
   system(("mkdir -p " + siblings_path).c_str());
   system(("mkdir -p " + non_siblings_path).c_str());
   
+  output_file_single_muon = new TFile((single_muon_path + file_name).c_str(), "recreate");
   output_file_siblings = new TFile((siblings_path + file_name).c_str(), "recreate");
   output_file_non_siblings = new TFile((non_siblings_path + file_name).c_str(), "recreate");
+  
+  output_file_single_muon->cd();
+  auto tree_single = input_tree->CloneTree(0);
   
   output_file_siblings->cd();
   auto tree_siblings = input_tree->CloneTree(0);
@@ -42,13 +48,14 @@ tuple<TTree*, TTree*> get_output_trees(TTree *input_tree, string siblings_path, 
   output_file_non_siblings->cd();
   auto tree_non_siblings = input_tree->CloneTree(0);
   
-  return {tree_siblings, tree_non_siblings};
+  return {tree_single, tree_siblings, tree_non_siblings};
 }
 
 int main(int argc, char *argv[])
 {
-  if(argc != 5){
-    cout<<"Usage: ./apply_selections file_name input_path output_siblings_path output_non_siblings_path"<<endl;
+  if(argc != 6){
+    cout<<"Usage: ./apply_selections file_name input_path output_path_single_muon";
+    cout<<" output_siblings_path output_non_siblings_path"<<endl;
     exit(0);
   }
   
@@ -56,7 +63,8 @@ int main(int argc, char *argv[])
   string input_path = argv[2];
   
   auto input_tree = get_input_tree(input_path+file_name);
-  auto [output_tree_siblings, output_tree_non_siblings] = get_output_trees(input_tree, argv[3], argv[4], file_name);
+  auto [output_tree_single_muon, output_tree_siblings, output_tree_non_siblings] =
+  get_output_trees(input_tree, file_name, argv[3], argv[4], argv[5]);
   
 // load events
   auto event_reader = EventReader(max_events, n_daughters);
@@ -68,7 +76,9 @@ int main(int argc, char *argv[])
     {"1_tt_pair", 0},
     {"2_n_muons_ge_2", 0},
     {"3_n_non_top_muons_ge_2", 0},
-    {"4_has_os_muon_siblins", 0}
+    {"4_single_muon", 0},
+    {"5_muon_pair", 0},
+    {"6_muon_non_pair", 0},
   };
   
   int i_event=0;
@@ -85,24 +95,25 @@ int main(int argc, char *argv[])
     if(!event->has_ttbar_pair()) continue;
     cut_flow["1_tt_pair"]++;
     
-    // n muons >= 2
-    if(event->get_n_muons() < 2) continue;
-    cut_flow["2_n_muons_ge_2"]++;
-    
-    // n non-top (62) muons >= 2
-    if(event->get_n_non_top_muons() < 2) continue;
-    cut_flow["3_n_non_top_muons_ge_2"]++;
-    
     // check if has opposite-sign muon siblings
-    if(!event->are_non_top_muons_siblings()){
+    int preselection_code = event->passes_preselection();
+    
+    if(preselection_code == 0) continue;
+    else if(preselection_code == 1){ // single muon tree
+      cut_flow["4_single_muon"]++;
+      output_file_single_muon->cd();
+      output_tree_single_muon->Fill();
+    }
+    else if(preselection_code == 2){ // pair category
+      cut_flow["5_muon_pair"]++;
+      output_file_siblings->cd();
+      output_tree_siblings->Fill();
+    }
+    else if(preselection_code == 3){ // non-pair category
+      cut_flow["6_muon_non_pair"]++;
       output_file_non_siblings->cd();
       output_tree_non_siblings->Fill();
-      continue;
     }
-    cut_flow["4_has_os_muon_siblins"]++;
-    
-    output_file_siblings->cd();
-    output_tree_siblings->Fill();
   }
   
   cout<<"\n\nCut flow: "<<endl;

--- a/selection_tools/include/Event.hpp
+++ b/selection_tools/include/Event.hpp
@@ -28,7 +28,7 @@ public:
   
   bool has_two_opposite_sign_muons();
   bool has_ttbar_pair();
-  bool are_non_top_muons_siblings();
+  int passes_preselection();
   
   std::vector<Particle*> particles;
 
@@ -37,7 +37,7 @@ private:
   void setup_motherless_particles();
   
   std::vector<int> get_sisters_indices(Particle *mother, int i_particle);
-  std::tuple<bool, bool> check_sister(int sister_index, Particle *particle, std::vector<Particle*> particles);
+  int check_sister(int sister_index, Particle *particle, std::vector<Particle*> particles);
 };
 
 #endif /* Event_hpp */

--- a/selection_tools/include/Particle.hpp
+++ b/selection_tools/include/Particle.hpp
@@ -7,6 +7,8 @@
 
 #include <vector>
 
+#include <TLorentzVector.h>
+
 class Particle
 {
 public:
@@ -17,14 +19,22 @@ public:
   void print();
   
   bool is_muon(){return abs(pdgid)==13;}
+  bool is_good_non_top_muon(const std::vector<Particle*> &particles);
+  bool is_motherless();
   
   bool has_top_ancestor(const std::vector<Particle*> &other_particles);
   bool is_final();
+  
+  double eta();
+  double momentum();
+  
   
   float x, y, z, px, py, pz, energy, mass, ctau;
   std::vector<int> mothers, daughters;
   int pdgid, status, index, barcode;
   bool is_selfmother;
+  
+  TLorentzVector four_vector;
 };
 
 

--- a/selection_tools/src/Particle.cpp
+++ b/selection_tools/src/Particle.cpp
@@ -15,6 +15,9 @@ x(_x), y(_y), z(_z), px(_px), py(_py), pz(_pz), energy(_energy), mass(_mass), ct
 pdgid(_pdgid), daughters(_daughters), status(_status), index(_index), barcode(_barcode)
 {
   is_selfmother = false;
+  
+  four_vector = TLorentzVector();
+  four_vector.SetPxPyPzE(px, py, pz, energy);
 }
 
 void Particle::print()
@@ -26,6 +29,30 @@ void Particle::print()
   cout<<"\tbar: "<<barcode<<endl;
 }
 
+bool Particle::is_good_non_top_muon(const vector<Particle*> &particles)
+{
+  if(!is_final()) return false;
+  if(abs(pdgid) != 13) return false;
+  if(fabs(eta()) > 2.5) return false;
+  if(has_top_ancestor(particles)) return false;
+  
+  if(pow(energy, 2) - pow(momentum(), 2) < 0){
+    cout<<"found weird momentum"<<endl;
+    return false;
+  }
+  return true;
+}
+
+bool Particle::is_motherless()
+{
+  if(mothers.size() == 0) return true;
+  
+  for(int mother_index : mothers){
+    if(mother_index < 0) return true;
+  }
+  
+  return false;
+}
 
 bool Particle::has_top_ancestor(const vector<Particle*> &other_particles)
 {
@@ -46,4 +73,14 @@ bool Particle::is_final()
   if(abs(pdgid) == 6) return status == 62;
   
   return true;
+}
+
+double Particle::eta()
+{
+  return four_vector.Eta();
+}
+
+double Particle::momentum()
+{
+  return four_vector.P();
 }


### PR DESCRIPTION
Adding changes in selection tools we implemented today + some small cleanup + I realized that we didn't apply all checks (like eta < 2.5) to potential sisters of a given muon. This last point changes very slightly the results (some muon pairs were degraded to muon non-pairs).